### PR TITLE
Posting picture from front

### DIFF
--- a/src/backend/clearboard/main.py
+++ b/src/backend/clearboard/main.py
@@ -2,11 +2,12 @@
 core_address : string, defines the part of the url that wont change between several jitsi-box
 origins : string[], url to whitelist and on which the fastapi server should listen (basicly the core address)
 """
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
 from functools import lru_cache
 from . import config
-
+import shutil
+import os
 
 app = FastAPI()
 
@@ -32,3 +33,17 @@ async def get_policy(custom_address: str = "picture", settings: config.Settings 
     """custom_address: string, part of the url that identify one meeting from another """
     data = {"url": f"{settings.core_address}{custom_address}"}
     return data
+
+
+@app.post("/picture")
+async def post_picture(file: UploadFile = File(...)):
+    if not file:
+        return {"message": "error"}
+    else:
+        path = f"./{file.filename[:-4]}"
+        print(path)
+        if not os.path.exists(path):
+            os.makedirs(path)
+        with open(f"{path}/{file.filename}", 'wb') as f:
+            shutil.copyfileobj(file.file, f)
+        return {"message": file.filename}

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -49,6 +49,7 @@ dev =
     pytest-django==4.5.2
     pytest==6.2.5
     python-dotenv==0.19.2
+    python-multipart==0.0.5
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
## Purpose

setting post request to get picture taken by a front end server and saving it in a specified folder (one by meeting) that can be created if needed. 

Note : 
One working with AWS buckets should consider using custom policies and disable fastapi's post listening 
